### PR TITLE
Support Source Sans Pro font with alternative name

### DIFF
--- a/lib.typ
+++ b/lib.typ
@@ -150,7 +150,7 @@
   )
   
   set text(
-    font: ("Source Sans Pro"),
+    font: ("Source Sans Pro", "Source Sans 3"),
     lang: language,
     size: 11pt,
     fill: color-darkgray,


### PR DESCRIPTION
When I install the Sans Source Pro font from the linked repository on Windows 10 they appear as "Source Sans 3".
This PR adds this name to the font parameter.