### PR TITLE
No space between first and last name for Japanese and Chinese languages

### DIFF
--- a/.github/workflows/build-documentation.yml
+++ b/.github/workflows/build-documentation.yml
@@ -7,7 +7,9 @@ jobs:
       - name: Set up Git repository
         uses: actions/checkout@v4
       - name: Install fonts
-        run: sudo apt-get install fonts-font-awesome fonts-roboto texlive-fonts-recommended texlive-fonts-extra
+        run: |
+          sudo apt update
+          sudo apt-get install fonts-font-awesome fonts-roboto texlive-fonts-recommended texlive-fonts-extra
       - name: Typst
         uses: yusancky/setup-typst@v2
         id: setup-typst

--- a/lib.typ
+++ b/lib.typ
@@ -269,7 +269,9 @@
       weight: "bold",
     )
     align(center)[
-      #author.address
+      #if ("address" in author) [
+        #author.address
+      ]
     ]
   }
   
@@ -286,21 +288,21 @@
       )
       #block[
         #align(horizon)[
-          #if author.phone != none [
+          #if ("phone" in author) [
             #phone-icon
             #box[#text(author.phone)]
             #separator
           ]
-          #if author.email != none [
+          #if ("email" in author) [
             #email-icon
             #box[#link("mailto:" + author.email)[#author.email]]
           ]
-          #if author.github != none [
+          #if ("github" in author) [
             #separator
             #github-icon
             #box[#link("https://github.com/" + author.github)[#author.github]]
           ]
-          #if author.linkedin != none [
+          #if ("linkedin" in author) [
             #separator
             #linkedin-icon
             #box[
@@ -528,7 +530,9 @@
       fill: color-gray,
     )
     align(right)[
-      #author.address
+      #if ("address" in author) [
+        #author.address
+      ]
     ]
   }
   
@@ -548,21 +552,21 @@
           #stack(
             dir: ltr,
             spacing: 0.5em,
-            if author.phone != none [
+            if ("phone" in author) [
               #phone-icon
               #box[#text(author.phone)]
               #separator
             ],
-            if author.email != none [
+            if ("email" in author) [
               #email-icon
               #box[#link("mailto:" + author.email)[#author.email]]
             ],
-            if author.github != none [
+            if ("github" in author) [
               #separator
               #github-icon
               #box[#link("https://github.com/" + author.github)[#author.github]]
             ],
-            if author.linkedin != none [
+            if ("linkedin" in author) [
               #separator
               #linkedin-icon
               #box[

--- a/lib.typ
+++ b/lib.typ
@@ -169,8 +169,11 @@
         #smallcaps[#date]
       ][
         #smallcaps[
-          #author.firstname
-          #author.lastname
+          #if language == "zh" or language == "ja" [
+            #author.firstname#author.lastname
+          ] else [
+            #author.firstname#sym.space#author.lastname
+          ]
           #sym.dot.c
           #linguify("resume", from: lang_data)
         ]
@@ -241,8 +244,12 @@
             style: "normal",
             font: ("Roboto"),
           )
-          #text(fill: accent-color, weight: "thin")[#author.firstname]
-          #text(weight: "bold")[#author.lastname]
+          #if language == "zh" or language == "ja" [
+            #text(accent-color, weight: "thin")[#author.firstname]#text(weight: "bold")[#author.lastname]
+          ] else [
+            #text(accent-color, weight: "thin")[#author.firstname]
+            #text(weight: "bold")[#author.lastname]
+          ]
         ]
       ]
     ]
@@ -452,8 +459,11 @@
         #smallcaps[#date]
       ][
         #smallcaps[
-          #author.firstname
-          #author.lastname
+          #if language == "zh" or language == "ja" [
+            #author.firstname#author.lastname
+          ] else [
+            #author.firstname#sym.space#author.lastname
+          ]
           #sym.dot.c
           #linguify("cover-letter", from: lang_data)
         ]
@@ -501,8 +511,13 @@
             style: "normal",
             font: ("Roboto"),
           )
-          #text(accent-color, weight: "thin")[#author.firstname]
-          #text(weight: "bold")[#author.lastname]
+          #if language == "zh" or language == "ja" [
+            #text(accent-color, weight: "thin")[#author.firstname]#text(weight: "bold")[#author.lastname]
+          ] else [
+            #text(accent-color, weight: "thin")[#author.firstname]
+            #text(weight: "bold")[#author.lastname]
+          ]
+          
         ]
       ]
     ]


### PR DESCRIPTION
For chinese and japanese, don't use a space between the firstname and lastname.

Fixes #37 