### PR TITLE
Mmake address optional

### DIFF
--- a/.github/workflows/build-documentation.yml
+++ b/.github/workflows/build-documentation.yml
@@ -7,7 +7,9 @@ jobs:
       - name: Set up Git repository
         uses: actions/checkout@v4
       - name: Install fonts
-        run: sudo apt-get install fonts-font-awesome fonts-roboto texlive-fonts-recommended texlive-fonts-extra
+        run: |
+          sudo apt update
+          sudo apt-get install fonts-font-awesome fonts-roboto texlive-fonts-recommended texlive-fonts-extra
       - name: Typst
         uses: yusancky/setup-typst@v2
         id: setup-typst

--- a/lib.typ
+++ b/lib.typ
@@ -269,7 +269,9 @@
       weight: "bold",
     )
     align(center)[
-      #author.address
+      #if ("address" in author) [
+        #author.address
+      ]
     ]
   }
   
@@ -286,21 +288,21 @@
       )
       #block[
         #align(horizon)[
-          #if author.phone != none [
+          #if ("phone" in author) [
             #phone-icon
             #box[#text(author.phone)]
             #separator
           ]
-          #if author.email != none [
+          #if ("email" in author) [
             #email-icon
             #box[#link("mailto:" + author.email)[#author.email]]
           ]
-          #if author.github != none [
+          #if ("github" in author) [
             #separator
             #github-icon
             #box[#link("https://github.com/" + author.github)[#author.github]]
           ]
-          #if author.linkedin != none [
+          #if ("linkedin" in author) [
             #separator
             #linkedin-icon
             #box[
@@ -528,7 +530,9 @@
       fill: color-gray,
     )
     align(right)[
-      #author.address
+      #if ("address" in author) [
+        #author.address
+      ]
     ]
   }
   
@@ -548,21 +552,21 @@
           #stack(
             dir: ltr,
             spacing: 0.5em,
-            if author.phone != none [
+            if ("phone" in author) [
               #phone-icon
               #box[#text(author.phone)]
               #separator
             ],
-            if author.email != none [
+            if ("email" in author) [
               #email-icon
               #box[#link("mailto:" + author.email)[#author.email]]
             ],
-            if author.github != none [
+            if ("github" in author) [
               #separator
               #github-icon
               #box[#link("https://github.com/" + author.github)[#author.github]]
             ],
-            if author.linkedin != none [
+            if ("linkedin" in author) [
               #separator
               #linkedin-icon
               #box[


### PR DESCRIPTION
Made `author.address` optional. Also improved how other fields in the `author` dictionary are checked so they can be omitted completely if the user so chooses. Currently they must be left empty to be omitted.

Fixes #36 