### PR TITLE
Update README example to use 0.4.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ See `typst fonts --help` for more information on configuring fonts for `typst` t
 Below is a basic example for a simple resume:
 
 ```typst
-#import "@preview/modern-cv:0.1.0": *
+#import "@preview/modern-cv:0.4.0": *
 
 #show: resume.with(
   author: (


### PR DESCRIPTION
As a new user (to typst and to modern-cv), I copy-pasted the example, got it working, and then started modifying using features released post 0.1.0 (such as `colored-headers`). It took me a while to figure out that the import is of a very old version.

PS: thank you for this package, works very well.