### PR TITLE
Add ORCID links with icons in the header 

### DIFF
--- a/lib.typ
+++ b/lib.typ
@@ -21,6 +21,9 @@
 #let google-scholar-icon = box(
   fa-icon("google-scholar", fill: color-darknight),
 )
+#let orcid-icon = box(
+  fa-icon("orcid", fill: color-darknight),
+)
 #let phone-icon = box(fa-icon("square-phone", fill: color-darknight))
 #let email-icon = box(fa-icon("envelope", fill: color-darknight))
 #let birth-icon = box(fa-icon("cake", fill: color-darknight))
@@ -343,6 +346,11 @@
             #separator
             #google-scholar-icon
             #box[#link("https://scholar.google.com/citations?user=" + author.scholar)[#fullname]]
+          ]
+          #if ("orcid" in author) [
+            #separator
+            #orcid-icon
+            #box[#link("https://orcid.org/" + author.orcid)[#author.orcid]]
           ]
         ]
       ]

--- a/template/resume.typ
+++ b/template/resume.typ
@@ -9,6 +9,7 @@
     github: "DeveloperPaul123",
     twitter: "typstapp",
     scholar: "",
+    orcid: "0000-0000-0000-000X",
     birth: "January 1, 1990",
     linkedin: "Example",
     address: "111 Example St. Example City, EX 11111",


### PR DESCRIPTION
Thank you so much for the template. It’s the best one I’ve found and fits my needs perfectly.
Following #45 , this PR added the [ORCID](https://orcid.org/) link and icon, which might be convenient for those, including myself, who use ORCID.
