### PR TITLE
Hide date and description when both are empty

### DIFF
--- a/lib.typ
+++ b/lib.typ
@@ -410,7 +410,9 @@
   
   pad[
     #justified-header(title-content, location)
-    #secondary-justified-header(description, date)
+    #if description != "" or date != "" [
+      #secondary-justified-header(description, date)
+    ]
   ]
 }
 


### PR DESCRIPTION
to avoid the empty line when both date and description are set to empty string or not present