### PR TITLE
Add font input for resume and coverletter

### DIFF
--- a/lib.typ
+++ b/lib.typ
@@ -147,6 +147,7 @@
   accent-color: default-accent-color,
   colored-headers: true,
   language: "en",
+  font: ("Source Sans Pro", "Source Sans 3"),
   body,
 ) = {
   if type(accent-color) == "string" {
@@ -161,7 +162,7 @@
   )
   
   set text(
-    font: ("Source Sans Pro", "Source Sans 3"),
+    font: font,
     lang: language,
     size: 11pt,
     fill: color-darkgray,

--- a/lib.typ
+++ b/lib.typ
@@ -482,6 +482,7 @@
   date: datetime.today().display("[month repr:long] [day], [year]"),
   accent-color: default-accent-color,
   language: "en",
+  font: ("Source Sans Pro", "Source Sans 3"),
   body,
 ) = {
   if type(accent-color) == "string" {
@@ -497,7 +498,7 @@
   )
   
   set text(
-    font: ("Source Sans Pro", "Source Sans 3"),
+    font: font,
     lang: language,
     size: 11pt,
     fill: color-darkgray,

--- a/template/coverletter.typ
+++ b/template/coverletter.typ
@@ -17,6 +17,7 @@
   ),
   profile-picture: image("./profile.png"),
   language: "en",
+  font: "Times New Roman"
 )
 
 #hiring-entity-info(entity-info: (

--- a/template/resume.typ
+++ b/template/resume.typ
@@ -54,6 +54,17 @@
   - #lorem(25)
 ]
 
+#resume-entry(
+  title: "Intern",
+  location: "Example City, EX",
+)
+
+#resume-item[
+  - #lorem(20)
+  - #lorem(15)
+  - #lorem(25)
+]
+
 = Projects
 
 #resume-entry(


### PR DESCRIPTION
You can now specify the font for the resume and coverletter.

Fixes #50 

Example:

```typst
#show: coverletter.with(
  author: (
    firstname: "John",
    lastname: "Smith",
    email: "js@gmail.com",
    homepage: "https://example.com",
    phone: "(+1) 111-111-1111",
    github: "DeveloperPaul123",
    linkedin: "John Smith",
    address: "111 Example St. Apt. 111, Example City, EX 11111",
    positions: (
      "Software Engineer",
      "Full Stack Developer",
    ),
  ),
  profile-picture: image("./profile.png"),
  language: "en",
  font: "Times New Roman"
)
```