### PR TITLE
Formatting parity between cover letter and resume author info

### DIFF
--- a/lib.typ
+++ b/lib.typ
@@ -365,7 +365,7 @@
             #separator
             #linkedin-icon
             #box[
-              #link("https://www.linkedin.com/in/" + author.linkedin)[#author.linkedin]
+              #link("https://www.linkedin.com/in/" + author.linkedin)[#author.firstname #author.lastname]
             ]
           ]
           #if ("twitter" in author) [
@@ -655,6 +655,11 @@
                 #link("https://www.linkedin.com/in/" + author.linkedin)[#author.firstname #author.lastname]
               ]
             ],
+            if ("orcid" in author) [
+              #separator
+              #orcid-icon
+              #box[#link("https://orcid.org/" + author.orcid)[#author.orcid]]
+           ],            
           )
         ]
       ]


### PR DESCRIPTION
These are small quick changes to add some parity between the cover letter and resume header.

Specifically, I noticed that the cover letter used the author name in the LinkedIn field (e.g., John Doe) whereas the resume kept the id (e.g., johndoe). Also, cover letter lacked OrcID so I just copied/pasted that down to the cover letter section as well. 

My solutions are novice copy/paste edits, and I'm not familiar with this syntax, but it did work in my own testing. Please carefully review and feel free to add/edit/ignore.

I'm sure there's other fields that don't match up exactly, but those are the two I use. Cheers and great work on this!