### PR TITLE
feat: use multi-language data for PDF title

### DIFF
--- a/lib.typ
+++ b/lib.typ
@@ -208,7 +208,7 @@
   
   set document(
     author: author.firstname + " " + author.lastname,
-    title: "resume",
+    title: linguify("resume", from: lang_data),
   )
   
   set text(
@@ -552,7 +552,7 @@
   
   set document(
     author: author.firstname + " " + author.lastname,
-    title: "cover-letter",
+    title: linguify("cover-letter", from: lang_data),
   )
   
   set text(


### PR DESCRIPTION
When compiling a PDF using the template, I noticed that the multilanguage information was not yet used for the title metadata of the resulting file. This PR adjusts the template to use the `lang_data` to include that information.