### PR TITLE
Add the ability to set a profile picture in resume

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ Below is a basic example for a simple resume:
         "Software Architect"
       )
   ),
+  profile-picture: none,
   date: datetime.today().display()
 )
 

--- a/lib.typ
+++ b/lib.typ
@@ -184,6 +184,7 @@
 /// The original template: https://github.com/posquit0/Awesome-CV
 ///
 /// - author (content): Structure that takes in all the author's information
+/// - profile-picture (image): The profile picture of the author. This will be cropped to a circle and should be square in nature.
 /// - date (string): The date the resume was created
 /// - accent-color (color): The accent color of the resume
 /// - colored-headers (boolean): Whether the headers should be colored or not
@@ -192,6 +193,7 @@
 /// -> none
 #let resume(
   author: (:),
+  profile-picture: image,
   date: datetime.today().display("[month repr:long] [day], [year]"),
   accent-color: default-accent-color,
   colored-headers: true,
@@ -399,11 +401,37 @@
     ]
   }
   
-  name
-  positions
-  address
-  contacts
+  if profile-picture != none {
+    grid(
+      columns: (100% - 4cm, 4cm),
+      rows: (100pt),
+      gutter: 10pt,
+      [
+        #name
+        #positions
+        #address
+        #contacts
+      ],
+      align(left + horizon)[
+        #block(
+          clip: true,
+          stroke: 0pt,
+          radius: 2cm,
+          width: 4cm,
+          height: 4cm,
+          profile-picture,
+        )
+      ],
+    )
+  } else {
+    name
+    positions
+    address
+    contacts
+  }
+
   body
+
 }
 
 /// The base item for resume entries.

--- a/template/resume.typ
+++ b/template/resume.typ
@@ -20,6 +20,7 @@
       "Developer",
     ),
   ),
+  profile-picture: none,
   date: datetime.today().display(),
   language: "en",
   colored-headers: true,


### PR DESCRIPTION
Hi there,

This is my attempt to add a profile picture in the resume template (see #56).

Here is the result:

![resume](https://github.com/user-attachments/assets/0b719f79-5965-4dc9-ad11-cd2b1ab0da49)

Thanks,

Clément