### PR TITLE
Use provided font for header name

### DIFF
--- a/lib.typ
+++ b/lib.typ
@@ -198,6 +198,7 @@
   show-footer: true,
   language: "en",
   font: ("Source Sans Pro", "Source Sans 3"),
+  header-font: ("Roboto"),
   body,
 ) = {
   if type(accent-color) == "string" {
@@ -286,7 +287,7 @@
           #set text(
             size: 32pt,
             style: "normal",
-            font: font,
+            font: header-font,
           )
           #if language == "zh" or language == "ja" [
             #text(

--- a/lib.typ
+++ b/lib.typ
@@ -286,7 +286,7 @@
           #set text(
             size: 32pt,
             style: "normal",
-            font: ("Roboto"),
+            font: font,
           )
           #if language == "zh" or language == "ja" [
             #text(


### PR DESCRIPTION
Use specified (or default) font also for the name in the header, instead of the hardcoded "Roboto"