### PR TITLE
fix: allow font awesome icon in heading

### DIFF
--- a/lib.typ
+++ b/lib.typ
@@ -260,7 +260,7 @@
     } else {
       color-darkgray
     }
-    #text[#strong[#text(color)[#it.body.text]]]
+    #text[#strong[#text(color)[#it.body]]]
     #box(width: 1fr, line(length: 100%))
   ]
   
@@ -632,7 +632,7 @@
     )
     
     #align(left)[
-      #text[#strong[#text(accent-color)[#it.body.text]]]
+      #text[#strong[#text(accent-color)[#it.body]]]
       #box(width: 1fr, line(length: 100%))
     ]
   ]


### PR DESCRIPTION
close #86. Allow font awesome icon in the heading like this:
```
= #fa-icon("cogs", fill: blue, size: 12pt) Experience
```

and output: 
![截图 2025-01-11 13-58-56](https://github.com/user-attachments/assets/25b69509-b999-4ae0-ac7b-041291aa4bbb)
