### PR TITLE
Fix German salutation

### DIFF
--- a/lang.toml
+++ b/lang.toml
@@ -15,7 +15,7 @@ dear = "Sehr geehrte"
 cover-letter = "Anschreiben"
 attached = "Angehängt"
 curriculum-vitae = "Lebenslauf"
-sincerely = "Aufrichtig"
+sincerely = "Mit freundlichen Grüßen"
 
 [lang.gr]
 resume = "Βιογραφικό"

--- a/lib.typ
+++ b/lib.typ
@@ -774,7 +774,7 @@
         #text(weight: "light")[#linguify(
             "sincerely",
             from: lang_data,
-          )#sym.comma] \
+          )#if language != "de" [#sym.comma]] \
         #text(weight: "bold")[#author.firstname #author.lastname] \ \
       ]
     ]


### PR DESCRIPTION
"Aufrichtig" is the literal translation, but not used in German. The correct term is "Mit freundlichen Grüßen" and no comma. See for example [here](https://lebenslaufdesigns.de/anschreiben).