### PR TITLE
fix: use paper-size in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Below is a basic example for a simple resume:
   ),
   profile-picture: none,
   date: datetime.today().display(),
-  page-size: "us-letter"
+  paper-size: "us-letter"
 )
 
 = Education


### PR DESCRIPTION
In the README and therefore generated docs in Typst Universe there there is `page-size`, however template uses `paper-size`.
