### PR TITLE
Use type literals for comparison

### DIFF
--- a/lib.typ
+++ b/lib.typ
@@ -225,7 +225,7 @@
   use-smallcaps: true,
   body,
 ) = {
-  if type(accent-color) == "string" {
+  if type(accent-color) == str {
     accent-color = rgb(accent-color)
   }
   
@@ -507,7 +507,7 @@
   location-color: default-location-color,
 ) = {
   let title-content
-  if type(title-link) == "string" {
+  if type(title-link) == str {
     title-content = link(title-link)[#title]
   } else {
     title-content = title
@@ -608,7 +608,7 @@
   use-smallcaps: true,
   body,
 ) = {
-  if type(accent-color) == "string" {
+  if type(accent-color) == str {
     accent-color = rgb(accent-color)
   }
   


### PR DESCRIPTION
comparing strings with types is deprecated

This PR migrates to the new way of comparing types.