### PR TITLE
feat(lib): added icon to address entry

### DIFF
--- a/lib.typ
+++ b/lib.typ
@@ -21,6 +21,7 @@
 #let birth-icon = box(fa-icon("cake", fill: color-darknight))
 #let homepage-icon = box(fa-icon("home", fill: color-darknight))
 #let website-icon = box(fa-icon("globe", fill: color-darknight))
+#let address-icon = box(fa-icon("location-crosshairs", fill: color-darknight))
 
 /// Helpers
 
@@ -297,6 +298,7 @@
     set text(size: 9pt, weight: "regular")
     align(center)[
       #if ("address" in author) [
+        #address-icon
         #author.address
       ]
     ]
@@ -634,7 +636,8 @@
     set text(size: 9pt, weight: "bold", fill: color-gray)
     align(right)[
       #if ("address" in author) [
-        #author.address
+        #address-icon
+        #box[#text(author.address)]
       ]
     ]
   }

--- a/lib.typ
+++ b/lib.typ
@@ -201,6 +201,7 @@
   header-font: "Roboto",
   paper-size: "a4",
   use-smallcaps: true,
+  show-address-icon: false,
   body,
 ) = {
   if type(accent-color) == str {
@@ -298,8 +299,12 @@
     set text(size: 9pt, weight: "regular")
     align(center)[
       #if ("address" in author) [
-        #address-icon
-        #author.address
+        #if show-address-icon [
+          #address-icon
+          #box[#text(author.address)]
+        ] else [
+          #text(author.address)
+        ]
       ]
     ]
   }
@@ -544,6 +549,7 @@
   closing: none,
   paper-size: "a4",
   use-smallcaps: true,
+  show-address-icon: false,
   body,
 ) = {
   if type(accent-color) == str {
@@ -636,8 +642,12 @@
     set text(size: 9pt, weight: "bold", fill: color-gray)
     align(right)[
       #if ("address" in author) [
-        #address-icon
-        #box[#text(author.address)]
+        #if show-address-icon [
+          #address-icon
+          #box[#text(author.address)]
+        ] else [
+          #text(author.address)
+        ]
       ]
     ]
   }

--- a/template/coverletter.typ
+++ b/template/coverletter.typ
@@ -23,6 +23,8 @@
   // Remove the following line to show the footer
   // Or set the value to `true`
   show-footer: false,
+  // this defaults to false
+  show-address-icon: true,
   // set this to `none` to show the default or remove it completely
   closing: [],
   // see typst "page" documentation for more options

--- a/template/resume.typ
+++ b/template/resume.typ
@@ -25,6 +25,7 @@
   language: "en",
   colored-headers: true,
   show-footer: false,
+  show-address-icon: true,
   paper-size: "us-letter",
 )
 


### PR DESCRIPTION
Done in both the resume and coverletter. Continuation of #106. Also added an option to show/hide the address icon. 