### PR TITLE
feat: Add support for `custom` author entry

### DIFF
--- a/lib.typ
+++ b/lib.typ
@@ -378,16 +378,20 @@
             #website-icon
             #box[#link(author.website)[#author.website]]
           ]
-          #if ("custom" in author and "text" in author.custom) [
-            #separator
-            #if ("icon" in author.custom) [
-              #box(fa-icon(author.custom.icon, fill: color-darknight))
-            ]
-            #box[
-              #if ("link" in author.custom) [
-                #link(author.custom.link)[#author.custom.text]
-              ] else [
-                #author.custom.text
+          #if ("custom" in author and type(author.custom) == array) [
+            #for item in author.custom [
+              #if ("text" in item) [
+                #separator
+                #if ("icon" in item) [
+                  #box(fa-icon(item.icon, fill: color-darknight))
+                ]
+                #box[
+                  #if ("link" in item) [
+                    #link(item.link)[#item.text]
+                  ] else [
+                    #item.text
+                  ]
+                ]
               ]
             ]
           ]
@@ -562,7 +566,7 @@
 
 /// Cover letter template that is inspired by the Awesome CV Latex template by posquit0. This template can loosely be considered a port of the original Latex template.
 /// This coverletter template is designed to be used with the resume template.
-/// - author (content): Structure that takes in all the author's information. The following fields are required: firstname, lastname, positions. The following fields are used if available: email, phone, github, linkedin, orcid, address, website.
+/// - author (content): Structure that takes in all the author's information. The following fields are required: firstname, lastname, positions. The following fields are used if available: email, phone, github, linkedin, orcid, address, website, custom. The `custom` field is an array of additional entries with the following fields: text (string, required), icon (string, optional Font Awesome icon name), link (string, optional).
 /// - profile-picture (image): The profile picture of the author. This will be cropped to a circle and should be square in nature.
 /// - date (datetime): The date the cover letter was created. This will default to the current date.
 /// - accent-color (color): The accent color of the cover letter
@@ -728,24 +732,24 @@
         #box[#link(author.website)[#author.website]]
       ]
     }
-    if (
-      "custom" in author
-        and "text" in author.custom
-        and "show-in-contacts" in author.custom
-        and author.custom.show-in-contacts
-    ) {
-      author_list.push[
-        #if ("icon" in author.custom) [
-          #box(fa-icon(author.custom.icon, fill: color-darknight))
-        ]
-        #box[
-          #if ("link" in author.custom) [
-            #link(author.custom.link)[#author.custom.text]
-          ] else [
-            #author.custom.text
+
+    if ("custom" in author and type(author.custom) == array) {
+      for item in author.custom {
+        if ("text" in item) {
+          author_list.push[
+            #if ("icon" in item) [
+              #box(fa-icon(item.icon, fill: color-darknight))
+            ]
+            #box[
+              #if ("link" in item) [
+                #link(item.link)[#item.text]
+              ] else [
+                #item.text
+              ]
+            ]
           ]
-        ]
-      ]
+        }
+      }
     }
 
 

--- a/lib.typ
+++ b/lib.typ
@@ -378,6 +378,19 @@
             #website-icon
             #box[#link(author.website)[#author.website]]
           ]
+          #if ("custom" in author and "text" in author.custom) [
+            #separator
+            #if ("icon" in author.custom) [
+              #box(fa-icon(author.custom.icon, fill: color-darknight))
+            ]
+            #box[
+              #if ("link" in author.custom) [
+                #link(author.custom.link)[#author.custom.text]
+              ] else [
+                #author.custom.text
+              ]
+            ]
+          ]
         ]
       ]
     ]
@@ -713,6 +726,25 @@
       author_list.push[
         #website-icon
         #box[#link(author.website)[#author.website]]
+      ]
+    }
+    if (
+      "custom" in author
+        and "text" in author.custom
+        and "show-in-contacts" in author.custom
+        and author.custom.show-in-contacts
+    ) {
+      author_list.push[
+        #if ("icon" in author.custom) [
+          #box(fa-icon(author.custom.icon, fill: color-darknight))
+        ]
+        #box[
+          #if ("link" in author.custom) [
+            #link(author.custom.link)[#author.custom.text]
+          ] else [
+            #author.custom.text
+          ]
+        ]
       ]
     }
 

--- a/template/coverletter2.typ
+++ b/template/coverletter2.typ
@@ -14,6 +14,13 @@
       "Software Engineer",
       "Full Stack Developer",
     ),
+    custom: (
+      (
+        text: "Youtube Channel",
+        icon: "youtube",
+        link: "http://example.com",
+      ),
+    ),
   ),
   profile-picture: none,
   language: "sp",

--- a/template/resume.typ
+++ b/template/resume.typ
@@ -19,6 +19,13 @@
       "Software Architect",
       "Developer",
     ),
+    custom: (
+      (
+        text: "Youtube Channel",
+        icon: "youtube",
+        link: "https://example.com",
+      ),
+    ),
   ),
   profile-picture: image("profile.png"),
   date: datetime.today().display(),
@@ -139,7 +146,7 @@
 //       strong("Excel"),
 //       "Word",
 //       "Powerpoint",
-//       "Visual Studio", 
+//       "Visual Studio",
 //       "git",
 //       "Zed"
 //     ),


### PR DESCRIPTION
Hi, and thanks for the great `modern-cv` Typst library. It has been a pleasure to use it!

This PR adds support for a single `custom` field in the `author` metadata, allowing users to define a non-standard contact entry such as a blog, YouTube channel, or other link.

### Format

```typst
custom: (				// optional
  text: "Youtube Channel",		// required
  icon: "youtube",			// optional
  link: "http://example.com",		// optional
  show-in-contacts: true,		// optional
)
