### PR TITLE
[FEATURE] Added possibility to define author.signature as image to be added above author's name in signature block.

### DIFF
--- a/lib.typ
+++ b/lib.typ
@@ -628,6 +628,7 @@
   show-address-icon: false,
   description: none,
   keywords: (),
+  signature: image,
   body,
 ) = {
   if type(accent-color) == str {
@@ -843,6 +844,9 @@
   let signature = {
     align(bottom)[
       #pad(bottom: 2em)[
+        #if ("signature" in author) {
+          author.signature
+        }
         #text(weight: "light")[#linguify("sincerely", from: lang_data)#if (
             language != "de"
           ) [#sym.comma]] \

--- a/lib.typ
+++ b/lib.typ
@@ -844,7 +844,7 @@
   let signature = {
     align(bottom)[
       #pad(bottom: 2em)[
-        #if ("signature" in author) {
+        #if ("signature" in author and type(author.signature) == image) {
           author.signature
         }
         #text(weight: "light")[#linguify("sincerely", from: lang_data)#if (


### PR DESCRIPTION
I found the need to add my written signature to the signature block. I added it as signature property of the type image including a type check. I hope I didn't miss anything, I only discovered typst and modern-cv today.