### PR TITLE
[FEATURE] Possibility to add author.signature as image to be added above author's name in signature block.

### DIFF
--- a/lib.typ
+++ b/lib.typ
@@ -628,6 +628,7 @@
   show-address-icon: false,
   description: none,
   keywords: (),
+  signature: image,
   body,
 ) = {
   if type(accent-color) == str {
@@ -843,6 +844,9 @@
   let signature = {
     align(bottom)[
       #pad(bottom: 2em)[
+        #if ("signature" in author) {
+          author.signature
+        }
         #text(weight: "light")[#linguify("sincerely", from: lang_data)#if (
             language != "de"
           ) [#sym.comma]] \


### PR DESCRIPTION
I discovered typst and your modern-cv lib today. I found the need for adding my signature above my name in the signature block of the cover letter.
I tried adding a type check, but that broke adding the image.