### PR TITLE
fix: Icons and their text can get separated by automatic linebreaking

### DIFF
--- a/lib.typ
+++ b/lib.typ
@@ -438,10 +438,10 @@
       }
     }
 
-    align(center)[
+    align(center+horizon)[
       #set text(size: 9pt, weight: "regular", style: "normal")
       #block[
-        #align(horizon)[
+        #align(bottom)[
           #items.join(h(10pt))
         ]
       ]


### PR DESCRIPTION
I wrapped the contacts into additional boxes to ensure icons stay with text, as sometimes there would be inconvenient linebreaks in the CV. I also made the separator usage a bit more consistent, in a way similar to #82 as I just noticed-