### PR TITLE
fix: german `letter-position-pretext` translation

### DIFF
--- a/lang.toml
+++ b/lang.toml
@@ -17,7 +17,7 @@ cover-letter = "Anschreiben"
 attached = "Angehängt"
 curriculum-vitae = "Lebenslauf"
 sincerely = "Mit freundlichen Grüßen"
-letter-position-pretext = "Bewerbung für"
+letter-position-pretext = "Bewerbung als"
 
 [lang.gr]
 resume = "Βιογραφικό"


### PR DESCRIPTION
Since you're writing an application for a job position, "als" (as) must be used. Otherwise, it sounds like you're writing an application for or on behalf of other software engineers, which doesn't make a lot of sense.

This also became evident previously in the following issue, where someone already tried to adjust the translation: https://github.com/ptsouchlos/modern-cv/issues/98

The translation should still be made configurable, but the default needs to change anyway.