### PR TITLE
feat: Add devcontainer for template users

### DIFF
--- a/template/.devcontainer/Dockerfile
+++ b/template/.devcontainer/Dockerfile
@@ -1,0 +1,22 @@
+FROM ghcr.io/typst/typst:0.14.2
+
+# Install git and font-roboto
+RUN apk add git font-roboto
+
+# Install Source Sans Pro
+RUN wget https://github.com/adobe-fonts/source-sans/releases/download/3.006R/source-sans-pro-3.006R.zip
+RUN mkdir -p /usr/share/fonts/source-sans-pro
+RUN unzip source-sans-pro-3.006R.zip -d /usr/share/fonts/source-sans-pro
+RUN rm source-sans-pro-3.006R.zip
+
+# Install Source Sans 3
+RUN wget https://github.com/adobe-fonts/source-sans/releases/download/3.052R/OTF-source-sans-3.052R.zip
+RUN mkdir -p /usr/share/fonts/source-sans-3
+RUN unzip OTF-source-sans-3.052R.zip -d /usr/share/fonts/source-sans-3
+RUN rm OTF-source-sans-3.052R.zip
+
+# Install Font Awesome
+RUN wget https://use.fontawesome.com/releases/v7.1.0/fontawesome-free-7.1.0-desktop.zip
+RUN mkdir -p /usr/share/fonts/fontawesome
+RUN unzip fontawesome-free-7.1.0-desktop.zip -d /usr/share/fonts/fontawesome
+RUN rm fontawesome-free-7.1.0-desktop.zip

--- a/template/.devcontainer/Dockerfile
+++ b/template/.devcontainer/Dockerfile
@@ -1,0 +1,16 @@
+FROM ghcr.io/typst/typst:0.14.2
+
+# Install git and font-roboto
+RUN apk add git font-roboto
+
+# Install Source Sans 3
+RUN wget https://github.com/adobe-fonts/source-sans/releases/download/3.052R/OTF-source-sans-3.052R.zip
+RUN mkdir -p /usr/share/fonts/source-sans-3
+RUN unzip OTF-source-sans-3.052R.zip -d /usr/share/fonts/source-sans-3
+RUN rm OTF-source-sans-3.052R.zip
+
+# Install Font Awesome
+RUN wget https://use.fontawesome.com/releases/v7.1.0/fontawesome-free-7.1.0-desktop.zip
+RUN mkdir -p /usr/share/fonts/fontawesome
+RUN unzip fontawesome-free-7.1.0-desktop.zip -d /usr/share/fonts/fontawesome
+RUN rm fontawesome-free-7.1.0-desktop.zip

--- a/template/.devcontainer/devcontainer.json
+++ b/template/.devcontainer/devcontainer.json
@@ -1,0 +1,21 @@
+{
+  "name": "Typst Devcontainer",
+  "context": "..",
+  "dockerFile": "Dockerfile",
+  "remoteUser": "typst",
+  "workspaceFolder": "/workspace",
+  "mounts": [
+    "source=${localWorkspaceFolder},target=/workspace,type=bind,consistency=cached"
+  ],
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        // FIXME: tinymist 0.14.16 has issues, update only once it's fixed
+        // (see https://github.com/Myriad-Dreamin/tinymist/issues/2487)
+        "myriad-dreamin.tinymist@0.14.10",
+        // Spell checker
+        "elijah-potter.harper@2.0.0"
+      ]
+    }
+  }
+}


### PR DESCRIPTION
Hi,

Following discussion #182, here is a proposal to add a `devcontainer` for template's users.
Based on `typst` image, the devcontainer installs the fonts used in the template and Git.
If used in VScode it also installs `tinymist` for live preview etc. and `harper` for spell checking.

Thanks!
