### PR TITLE
feat: configurable profile picture diameter

### DIFF
--- a/lib.typ
+++ b/lib.typ
@@ -377,6 +377,7 @@
 ///
 /// - author (dictionary): Structure that takes in all the author's information
 /// - profile-picture (image): The profile picture of the author. This will be cropped to a circle and should be square in nature.
+/// - profile-picture-diameter (length): The diameter of the profile picture.
 /// - contact-items-separator (content): Separator to use between the "contact" items in the header of the resume. This includes items like your email, website, Github account, phone number and so on. The default is blank spacing.
 /// - contact-items-inset (dictionary): Gap between contact item icon and contact item text.
 /// - date (string): The date the resume was created
@@ -392,6 +393,7 @@
 #let resume(
   author: (:),
   profile-picture: image,
+  profile-picture-diameter: 4cm,
   contact-items-separator: h(10pt),
   contact-items-inset: (left: 4pt),
   date: datetime.today().display("[month repr:long] [day], [year]"),
@@ -546,33 +548,31 @@
     align(center, items.join(contact-items-separator))
   }
 
+  let header-content = [
+    #name
+    #positions
+    #address
+    #contacts
+  ]
+
   if profile-picture != none {
     grid(
-      columns: (100% - 4cm, 4cm),
-      rows: 100pt,
+      columns: (1fr, auto),
       gutter: 10pt,
-      [
-        #name
-        #positions
-        #address
-        #contacts
-      ],
-      align(left + horizon)[
-        #block(
-          clip: true,
-          stroke: 0pt,
-          radius: 2cm,
-          width: 4cm,
-          height: 4cm,
-          profile-picture,
-        )
-      ],
+      rows: 100pt,
+      align: horizon,
+      header-content,
+      block(
+        clip: true,
+        stroke: 0pt,
+        radius: profile-picture-diameter / 2,
+        width: profile-picture-diameter,
+        height: profile-picture-diameter,
+        profile-picture,
+      ),
     )
   } else {
-    name
-    positions
-    address
-    contacts
+    header-content
   }
 
   body

--- a/lib.typ
+++ b/lib.typ
@@ -559,7 +559,6 @@
     grid(
       columns: (1fr, auto),
       gutter: 10pt,
-      rows: 100pt,
       align: horizon,
       header-content,
       block(


### PR DESCRIPTION
If only a few contact items are used, the default profile picture diameter of 4cm looks too large, a smaller diameter is more suitable in these cases. Furthermore, the vertical alignment of the header is fixed.

| Before | After (4cm diameter) | After (3cm diameter) |
|:---:|:---:|:---:|
| <img width="1191" height="1684" alt="Image depicting the CV before the change" src="https://github.com/user-attachments/assets/2039a237-e625-4ad1-bdc2-1a447c31e191" /> | <img width="1191" height="1684" alt="Image depicting the CV after the change with a profile picture diameter of 4cm" src="https://github.com/user-attachments/assets/e99c23be-348e-44f6-9dc7-e89934e7d986" /> | <img width="1191" height="1684" alt="Image depicting the CV after the change with a profile picture diameter of 3cm (it looks visibly better :D)" src="https://github.com/user-attachments/assets/bea587e7-679d-4f7b-a8ad-0f0483f38f23" /> |