### PR TITLE
fix: regression in custom items

### DIFF
--- a/lib.typ
+++ b/lib.typ
@@ -134,7 +134,7 @@
     }
     // Then modify the selection to use the constant:
     #box(inset: inset)[
-      #if ("link" in item) {
+      #if ("link" in item) and type(item.link) == str {
         link(link-prefix + item.link)[#item.text]
       } else {
         item.text


### PR DESCRIPTION
Do not require a link for custom author entries.

Fixes #191 