### PR TITLE
Allow overriding the previously hard-coded space above and below a re…

### DIFF
--- a/lib.typ
+++ b/lib.typ
@@ -606,6 +606,8 @@
 /// - title-link (string): The link to use for the title (can be none)
 /// - accent-color (color): Override the accent color of the resume-entry
 /// - location-color (color): Override the default color of the "location" for a resume entry.
+/// - above (length): Override the space above the resume entry block (default: 1em)
+/// - below (length): Override the space below the resume entry block (default: 0.65em)
 #let resume-entry(
   title: none,
   location: "",
@@ -614,6 +616,8 @@
   title-link: none,
   accent-color: default-accent-color,
   location-color: default-location-color,
+  above: 1em,
+  below: 0.65em,
 ) = {
   let title-content
   if type(title-link) == str {
@@ -621,7 +625,7 @@
   } else {
     title-content = title
   }
-  block(above: 1em, below: 0.65em, sticky: true)[
+  block(above: above, below: below, sticky: true)[
     #pad[
       #justified-header(title-content, location)
       #if description != "" or date != "" [


### PR DESCRIPTION
The vertical spacing around `resume-entry` blocks was previously hardcoded to `1em` above and `0.65em` below. This change exposes those values as optional length parameters, preserving the existing defaults so there is no breaking change.

This allows users to adjust entry spacing to suit their layout without modifying the template directly.